### PR TITLE
Fixed Rain and Character Window Resizing 

### DIFF
--- a/splmns-animation/src/components/Character.jsx
+++ b/splmns-animation/src/components/Character.jsx
@@ -1,16 +1,39 @@
 import { motion, useMotionValue, useTransform, animate } from "framer-motion";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import "./Character.css";
 
 function Character({ name, type }) {
-  const startX = -300;
-  const endX = window.innerWidth + 300;
+  const width = window.innerWidth;
+  const height = width * (9 / 16);
+  const ampPercent = -0.55;
+  const [dimensions, setDimensions] = useState({
+    startX: -300,
+    endX: window.innerWidth + 300,
+    amplitude: ampPercent * height,
+  });
+  const { startX, endX, amplitude } = dimensions;
   const x = useMotionValue(startX);
-  const amplitude = -550;
   const theta = useTransform(x, [startX, endX], [0, Math.PI]);
   const arcY = useTransform(theta, (t) => amplitude * Math.sin(t));
   const className = type.movement === "ground" ? "sprite-ground" : "sprite-air";
   const y = type.movement === "air" ? arcY : 75;
+
+  useEffect(() => {
+    const updateDims = () => {
+      const newWidth = window.innerWidth;
+      const aspectHeight = newWidth * (9 / 16);
+
+      setDimensions({
+        startX: -300,
+        endX: newWidth + 300,
+        amplitude: ampPercent * aspectHeight,
+      });
+    };
+
+    updateDims(); // set once on mount
+    window.addEventListener("resize", updateDims);
+    return () => window.removeEventListener("resize", updateDims);
+  }, [startX, endX, amplitude, ampPercent]);
 
   const rotation = useTransform(theta, (t) => {
     const slope = amplitude * Math.cos(t);

--- a/splmns-animation/src/components/Character.jsx
+++ b/splmns-animation/src/components/Character.jsx
@@ -33,7 +33,7 @@ function Character({ name, type }) {
     updateDims(); // set once on mount
     window.addEventListener("resize", updateDims);
     return () => window.removeEventListener("resize", updateDims);
-  }, [startX, endX, amplitude, ampPercent]);
+  }, [ampPercent]);
 
   const rotation = useTransform(theta, (t) => {
     const slope = amplitude * Math.cos(t);

--- a/splmns-animation/src/components/RainOverlay.jsx
+++ b/splmns-animation/src/components/RainOverlay.jsx
@@ -3,11 +3,14 @@ import "./RainOverlay.css";
 
 function RainOverlay() {
   const canvasRef = useRef();
+  const animationRef = useRef();
+  const dropsRef = useRef([]);
+  const splashesRef = useRef([]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext("2d");
-    const splashProbabilty = 0.75;
+    const splashProbability = 0.75;
 
     function resizeCanvas() {
       canvas.width = window.innerWidth;
@@ -17,20 +20,21 @@ function RainOverlay() {
     resizeCanvas();
     window.addEventListener("resize", resizeCanvas);
 
+    // Initialize drops
     const numDrops = 150;
-    const drops = Array.from({ length: numDrops }, () => ({
+    dropsRef.current = Array.from({ length: numDrops }, () => ({
       x: Math.random() * canvas.width,
       y: Math.random() * canvas.height,
       speed: 4 + Math.random() * 4,
       color: Math.random() < 0.5 ? "white" : "blue",
     }));
 
-    const splashes = [];
+    splashesRef.current = [];
 
     function spawnSplash(x, y, color) {
       const count = 5 + Math.floor(Math.random() * 5);
       for (let i = 0; i < count; i++) {
-        splashes.push({
+        splashesRef.current.push({
           x,
           y,
           vx: (Math.random() - 0.5) * 4,
@@ -45,6 +49,9 @@ function RainOverlay() {
     function animate() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
+      const drops = dropsRef.current;
+      const splashes = splashesRef.current;
+
       drops.forEach((drop) => {
         ctx.beginPath();
         ctx.strokeStyle = drop.color;
@@ -55,7 +62,7 @@ function RainOverlay() {
 
         drop.y += drop.speed;
         if (drop.y > canvas.height) {
-          if (Math.random() < splashProbabilty) {
+          if (Math.random() < splashProbability) {
             spawnSplash(drop.x, canvas.height, drop.color);
           }
           drop.y = -10;
@@ -80,13 +87,14 @@ function RainOverlay() {
         }
       }
 
-      requestAnimationFrame(animate);
+      animationRef.current = requestAnimationFrame(animate);
     }
 
     animate();
 
     return () => {
-      cancelAnimationFrame(animate);
+      cancelAnimationFrame(animationRef.current);
+      window.removeEventListener("resize", resizeCanvas);
     };
   }, []);
 

--- a/splmns-animation/src/components/RainOverlay.jsx
+++ b/splmns-animation/src/components/RainOverlay.jsx
@@ -8,8 +8,14 @@ function RainOverlay() {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext("2d");
     const splashProbabilty = 0.75;
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
+
+    function resizeCanvas() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+
+    resizeCanvas();
+    window.addEventListener("resize", resizeCanvas);
 
     const numDrops = 150;
     const drops = Array.from({ length: numDrops }, () => ({

--- a/splmns-animation/src/components/RainOverlay.jsx
+++ b/splmns-animation/src/components/RainOverlay.jsx
@@ -20,7 +20,6 @@ function RainOverlay() {
     resizeCanvas();
     window.addEventListener("resize", resizeCanvas);
 
-    // Initialize drops
     const numDrops = 150;
     dropsRef.current = Array.from({ length: numDrops }, () => ({
       x: Math.random() * canvas.width,


### PR DESCRIPTION
## Summary

Air characters were originally only respecting `window.innerHeight` and ignoring 16/9 aspect ratio. Rain was not resizing at all, causing no-rain margins if window size was small on load and stretched afterwards. Resizing rain and characters now works with respect to aspect ratio and window size.

## Fix

- For aspect ratio, tied amplitude to a height defined by width * 16/9
- For rain, added resizing on window resize